### PR TITLE
docs: add arc-9 proposal

### DIFF
--- a/arc-9.md
+++ b/arc-9.md
@@ -16,30 +16,32 @@
 
 ## Summary
 
-This ARC proposes the integration of Prometheus metrics into Ampd to provide comprehensive monitoring capabilities. The implementation will expose key operational metrics through a Prometheus-compatible endpoint, enabling better observability of Ampd's performance and health.
+This ARC proposes integrating Prometheus metrics into AMPD to enhance observability. The system will expose key operational metrics via a Prometheus-compatible endpoint, enabling real-time monitoring of AMPD’s health and performance.
 
 ## Background and Motivation
 
-As AMPD grows in complexity—supporting more chains, verification mechanisms, and runtime environments—observability becomes essential for maintaining security, performance, and operational reliability.
+As AMPD grows in complexity, observability becomes essential for maintaining security, performance, and operational reliability.
 
-To address this, we are introducing structured, consistent, and low-overhead Prometheus metrics across core components of AMPD. The scope includes:
+To address this, we are introducing structured, consistent, and low-overhead Prometheus metrics across core components of AMPD. 
 
-- **The core AMPD daemon** (transaction execution, event handling)
-- **Chain connector modules** (e.g., Ethereum, Cosmos, Sui)
-- **Verifier modules** (e.g., Multisig, Voting)
-- **Runtime environments** (e.g., local and production deployments)
+The scope of this proposal includes:
 
-This enables us to:
+- **Core services and modules**:
+    Metrics will be instrumented in the AMPD daemon, chain connector modules (e.g., Ethereum, Cosmos, Sui), and verifier modules (e.g., Multisig, Voting).
+
+- **Deployment environments**:
+    The metrics system is designed to support both local development and production deployments, including containerized setups and Kubernetes-based infrastructure. 
+
+This integration will enable us to:
 
 - **Detect and investigate anomalies**  
-  Metrics like `ampd_errors_total` and `contract_execution_failures_total` help surface issues such as stuck transactions, verifier misbehavior, or degraded RPC performance—enabling faster debugging and recovery.
+  Counters such as `ampd_errors_total` and `contract_execution_failures_total` help surface issues such as stuck transactions, verifier misbehavior, or degraded RPC performance—enabling faster debugging and recovery.
 
 - **Identify performance bottlenecks**  
-  Histograms such as `ampd_transaction_duration_seconds` allow us to pinpoint slow chains or inefficient verification steps, supporting throughput optimization and latency reduction.
+    Histograms such as `ampd_transaction_duration_seconds` allow us to pinpoint slow chains or inefficient verification steps, supporting throughput optimization and latency reduction.
 
 - **Ensure operational transparency and readiness**  
-  Resource usage metrics like `ampd_cpu_usage_percent` and `ampd_memory_usage_bytes` help ensure AMPD runs within safe resource thresholds, especially in production environments with strict limits.
-
+  Resource usage metrics like `ampd_cpu_usage_percent` and `ampd_memory_usage_bytes` help ensure AMPD runs within safe resource thresholds.
 
 
 ## Architecture
@@ -47,25 +49,22 @@ This enables us to:
 The proposed metrics system will be implemented as a client-server architecture with the following key components:
 
 1. **Metrics Client**
-   - A thread-safe interface for components to record metrics
-   - Non-blocking message-based communication
-   - Simple API for recording metrics without exposing Prometheus internals
+   - Lightweight and thread-safe
+   - Uses non-blocking channels to send metric updates
 
 2. **Metrics Server**
-   - HTTP server exposing Prometheus-compatible endpoints
+   - Collects and exposes metrics via `/metrics` and `/status` endpoints
    - Central registry for all metrics
    - Message processing and metric updates
-   - Health check endpoint
 
 3. **Metrics Message**
-   - Type-safe enum-based message definitions
-   - Allows for modifying specific messages
+   - Type-safe, enum-based definitions for all metrics update messages
 
 ## Detailed Design 
 
 ### Overview
 
-The metrics system is integrated into Ampd's core components through a message-based client-server architecture. The MetricsClient is passed to key modules (ex: event handlers), enabling them to report metrics without knowing the internals of the Prometheus registry.
+The metrics system is integrated into Ampd's core components through a message-based client-server architecture. The `MetricsClient` is passed into AMPD’s core components (e.g., event handlers) and is used to emit metric updates asynchronously. Messages are processed by a central `MetricsServer`, which updates the corresponding metrics and exposes them via HTTP endpoints for external scraping.
 
 
 ### Message Types Specification
@@ -82,7 +81,7 @@ pub enum MetricsMsg {
 
 ### Client Implementation
 
-The MetricsClient provides a thread-safe, non-blocking interface for recording metrics. It uses a bounded channel with a capacity of 1000 (CHANNEL_SIZE) to queue metric update messages. 
+The MetricsClient provides a simple API for recording metrics. It uses a bounded channel with a capacity of 1000 (CHANNEL_SIZE) to queue metric update messages. 
 This number is chosen to handle expected peak loads, ensuring the system can process bursts of updates without exceeding resource limits.
 
 
@@ -104,15 +103,21 @@ impl MetricsClient {
 
 ### Server Implementation
 
-The `Server` component is responsible for receiving metric messages and exposing Prometheus-compatible endpoints. It operates in two modes: 
+The `Server` component is responsible for receiving metric messages and exposing Prometheus-compatible endpoints. It operates in one of the two modes: 
+
+#### Dummy Server Mode
+
+If the Prometheus server is disabled, the server runs in dummy mode. In this mode:
+
+- No HTTP endpoints are exposed.
+- All received metric messages are discarded.
+- The metrics interface remains available to the application, but no metrics are collected or exported.
 
 #### Live Server Mode
 
-In this mode, the server exposes HTTP endpoints for metrics collection and health checks. It processes incoming metric messages and updates the Prometheus registry accordingly.
+If the Prometheus server is enabled, the server will expose HTTP endpoints for metrics collection and health checks. It processes incoming metric messages and updates the Prometheus registry accordingly.
 
-The live server listens on the specified bind address and exposes two HTTP endpoints:
-
-The metrics server exposes two routes:
+The live server listens on the specified bind address and exposes two endpoints:
 
 1. `/metrics` — Returns Prometheus-formatted metrics:
 ```rust
@@ -130,15 +135,6 @@ async fn status() -> (StatusCode, Json<Status>) {
     (StatusCode::OK, Json(Status { ok: true }))
 }
 ```
-
-#### Dummy Server Mode
-
-If no bind address is provided, the server runs in dummy mode. In this mode:
-
-- No HTTP endpoints are exposed.
-- All received metric messages are discarded.
-- The metrics interface remains available to the application, but no metrics are collected or exported.
-
 
 
 ### Metrics Collection
@@ -177,24 +173,10 @@ The MetricsClient is injected into key components during application setup, enab
 
 
 ```rust
-if let StreamStatus::Active(Event::BlockEnd(height)) = &stream_status {
-    metric_client.record_metric(MetricsMsg::IncBlockReceived).ok();
+if let StreamStatus::Active(Event::BlockEnd(height)) = &stream_status { // specific event
+    metric_client.record_metric(MetricsMsg::IncBlockReceived).ok(); // use metrics client to update metrics
 }
 ```
-
-
-
-## Future Work
-
-### Metrics Expansion and Deployment
-
-- Define and implement additional metrics for verifier status, transaction results, and error rates
-- Extend Dockerfile and Helm charts to support metrics exposure and scraping
-
-### Custom Event Metrics Interface
-
-- Introduce a developer-friendly interface to define custom metrics per event type
-- Create a base schema for common metrics and utility functions for recording
 
 
 ## Changelog

--- a/arc-9.md
+++ b/arc-9.md
@@ -1,0 +1,217 @@
+# ARC-9: Prometheus Metrics Integration for Ampd
+
+## Metadata
+
+- **ARC ID**: 9
+
+- **Author(s)**: Yidan Wang
+
+- **Status**: Draft
+
+- **Created**: 2024-06-13
+
+- **Last Updated**: 2024-06-13
+
+- **Target Implementation**: Q3 2025
+
+## Summary
+
+This ARC proposes the integration of Prometheus metrics into Ampd to provide comprehensive monitoring capabilities. The implementation will expose key operational metrics through a Prometheus-compatible endpoint, enabling better observability of Ampd's performance and health.
+
+## Background and Motivation
+
+AMPD is a core component in Axelar's infrastructure that verifies cross-chain messages. Its reliability and correctness are critical for secure interchain communication. As the complexity and scale of the system grow, observability becomes essential to:
+
+- Detect and investigate anomalies (e.g., failed transactions, verifier issues)
+- Identify performance bottlenecks (e.g., block processing delays)
+- Provide confidence to operators and SREs through quantitative signals
+
+This ARC ensures Prometheus metrics are exposed in a structured, consistent, and low-overhead manner.
+
+## Architecture
+
+The proposed metrics system will be implemented as a client-server architecture with the following key components:
+
+1. **Metrics Client**
+   - A thread-safe interface for components to record metrics
+   - Non-blocking message-based communication
+   - Simple API for recording metrics without exposing Prometheus internals
+
+2. **Metrics Server**
+   - HTTP server exposing Prometheus-compatible endpoints
+   - Central registry for all metrics
+   - Message processing and metric updates
+   - Health check endpoint
+
+3. **Metrics Message**
+   - Type-safe enum-based message definitions
+   - Allows for modifying specific messages
+
+## Detailed Design (will be updated in the future)
+
+### Overview
+
+The metrics system is integrated into Ampd's core components through a message-based client-server architecture. The MetricsClient is passed to key modules (ex: event handlers), enabling them to report metrics without knowing the internals of the Prometheus registry.
+
+
+### Message Types Specification
+
+Metrics updates are modeled as enum variants for type safety and extensibility:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum MetricsMsg {
+    IncBlockReceived,
+    // will add other metrics here with explanation
+}
+```
+
+### Client Implementation
+
+The MetricsClient provides a non-blocking interface to send metric update messages over a bounded channel:
+
+```rust
+pub struct MetricsClient {
+    sender: mpsc::Sender<MetricsMsg>,
+}
+
+impl MetricsClient {
+    pub fn record_metric(&self, msg: MetricsMsg) -> Result<(), MetricsError> {
+        self.sender
+            .try_send(msg)
+            .change_context(MetricsError::MetricUpdateFailed)?;
+        Ok(())
+    }
+}
+```
+
+### Server Implementation
+
+The Server component initializes a receiver and an optional HTTP listener:
+
+```rust
+pub struct Server {
+    bind_address: Option<SocketAddrV4>,
+    metrics_rx: mpsc::Receiver<MetricsMsg>,
+}
+
+impl Server {
+    pub fn new(bind_address: Option<SocketAddrV4>) -> Result<(Self, MetricsClient), MetricsError> {
+        let (tx, rx) = mpsc::channel(CHANNEL_SIZE);
+        let client = MetricsClient::new(tx);
+        let server = Self {
+            bind_address,
+            metrics_rx: rx,
+        };
+        Ok((server, client))
+    }
+}
+```
+
+The server processes incoming metric messages and exposes /metrics via an Axum router.
+
+**Note:** If no bind address is provided, the server starts in a dummy mode. In this mode, it receives metric messages but does nothing with them—no HTTP endpoints are exposed, and no metrics are collected or exported. This ensures that the metrics interface remains available to the application even when metrics collection is not required.
+
+### Metrics Collection
+
+Metrics are stored in a struct and registered to a central prometheus::Registry. Messages are handled using a match block:
+
+```rust
+pub struct Metrics {
+    metrics: IntCounter,
+}
+
+impl Metrics {
+    pub fn new(registry: &Registry) -> Result<Self, MetricsError> {
+        let block_received = IntCounter::new("metrics_name", "description")
+            .change_context(MetricsError::MetricSpawnFailed)?;
+        // register metrics
+        registry
+            .register(Box::new(block_received.clone()))
+            .change_context(MetricsError::MetricRegisterFailed)?;
+
+        Ok(Self { block_received })
+    }
+
+    pub fn handle_message(&self, msg: MetricsMsg) {
+        match msg {
+            MetricsMsg::MetricsMsgType=> {
+                self.metrics.inc(); // handling logic here , will be different depending on the metrics
+                ...
+            }
+        }
+    }
+}
+```
+
+### Component Integration
+
+The metrics client is injected during application setup. For example, event handlers receive it during configuration:
+
+```rust
+fn create_handler_task<L, H>(
+    &mut self,
+    label: L,
+    handler: H,
+    event_processor_config: event_processor::Config,
+    metric_client: MetricsClient,  // Injected here
+) -> CancellableTask<Result<(), event_processor::Error>>
+```
+
+Within the event handler, metrics are recorded as follows:
+
+```rust
+if let StreamStatus::Active(Event::BlockEnd(height)) = &stream_status {
+    if let Err(err) = metric_client.record_metric(MetricsMsg::IncBlockReceived) {
+        warn!(
+            handler = handler_label,
+            height = height.value(),
+            err = %err,
+            "failed to update metrics for block end event"
+        );
+    }
+}
+```
+
+### HTTP Endpoints
+
+The metrics server exposes two routes:
+
+1. `/metrics` — Returns Prometheus-formatted metrics:
+```rust
+async fn gather_metrics(registry: &Registry) -> (StatusCode, String) {
+    match metrics::gather(registry) {
+        Ok(metrics) => (StatusCode::OK, metrics),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    }
+}
+```
+
+2. `/status` — Returns a simple OK response for health checks:
+```rust
+async fn status() -> (StatusCode, Json<Status>) {
+    (StatusCode::OK, Json(Status { ok: true }))
+}
+```
+
+## Future Work
+
+### Metrics Expansion and Deployment
+
+- Define and implement additional metrics for verifier status, transaction results, and error rates
+- Update CI/CD pipelines to deploy Ampd with Prometheus endpoints enabled
+- Extend Dockerfile and Helm charts to support metrics exposure and scraping
+
+### Custom Event Metrics Interface
+
+- Introduce a developer-friendly interface to define custom metrics per event type
+- Create a base schema for common metrics and utility functions for recording
+- Document best practices for metrics instrumentation within Ampd
+
+## Changelog
+
+| Date       | Revision | Author           | Description                                 |
+|------------|----------|------------------|---------------------------------------------|
+| 2025-xx-xx | v1.0     | Yidan Wang, Andrew Jia | Initial draft                           |
+| 2025-xx-xx  | v1.1    |            |        |
+| 2025-xx-xx  | v1.2    |             | |


### PR DESCRIPTION
AXE-9555
Note: This implementation is based on ARC-9 — Prometheus Metrics Integration for Ampd.
The proposal is still evolving and will be refined further, especially the architecture section.
Additional metrics will be implemented incrementally in future PRs as use cases are finalized.
https://www.notion.so/bright-ambert-2bd/Amplifier-Proposed-Prometheus-Metrics-1e6c53fccb7780afa9d0f7a0ff338e6d