### PR TITLE
feat(arc-17): sui custom token linking

### DIFF
--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -313,27 +313,13 @@ Only the assigned operator `Channel` can modify flow limits, providing security 
 
 Unlike EVM and other chains, Sui only supports two token manager types for custom tokens:
 
-#### LOCK_UNLOCK (`2`)
+#### LOCK_UNLOCK (`2u256`)
 
-Tokens are locked on source chain and unlocked from pre-existing supply on destination chain. Use this manager type for coins that meet the following criteria:
-- Existing tokens with established supply distribution
-- No minting authority available or desired
-- Simple integration without authority transfer
+Tokens are locked on source chain and unlocked from pre-existing supply on destination chain. To use this manager type, create a `CoinManagement` using the `new_locked<T>()` function.
 
-To use this manager type, create a `CoinManagement` using the `new_locked<T>()` function.
+#### MINT_BURN (`4u256`)
 
-#### MINT_BURN (`4`)
-
-Tokens are burned on source chain and minted on destination chain. Use this manager type for coins that meet the following criteria:
-- Dynamic supply management desired
-- New tokens being deployed cross-chain
-- Lock/unlock liquidity insufficient
-
-To use this manager type. create a `CoinManagement` using the `new_with_cap<T>(treasury_cap)` function.
-
-**`MINT_BURN` Requirements:**
-- Deployer must provide `TreasuryCap<T>` and transfer it to ITS
-- Returns `TreasuryCapReclaimer<T>` for reclaiming the `TreasuryCap`
+Tokens are burned on source chain and minted on destination chain To use this manager type. create a `CoinManagement` using the `new_with_cap<T>(treasury_cap)` function.
 
 ### Complete Process Flow
 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -218,7 +218,7 @@ public struct CoinManagement<phantom T> has store {
 | **Type Safety** | Runtime via address lookup | Compile-time via generic `<T>` |
 | **Authority Model** | Role-based (operator, minter) | Object-based (`TreasuryCap`, `Channel` addresses) |
 | **Minting & Burning** | Calls token.mint(), token.burn() with minter role | Directly mints and burns via `TreasuryCap` |
-| **Locking** | Transfers tokens to/from contract | Joins/splits Balance<T> |
+| **Locking** | Transfers tokens to/from contract | Joins/splits `Balance<T>` |
 
 #### CoinManagement Variants
 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -1,0 +1,311 @@
+# ARC-17: Sui Custom Token Linking
+
+## Metadata
+
+- **ARC ID**: 17
+- **Author(s)**: Drew Taylor
+- **Category**: Interchain Token Protocol
+- **Status**: Final
+- **Created**: 2025-11-3
+- **Last Updated**: 2025-11-3
+- **Deployment Status**: Live
+
+## Summary
+
+This ARC specifies the implementation of custom token linking for Sui in the Interchain Token Service (ITS). Custom token linking enables existing Sui coins to be linked with tokens on other chains while supporting different decimal precisions through ITS Hub's automatic scaling. This specification details the Sui-specific patterns, `Channel`-based identity model, `CoinManagement` structure, and key architectural differences from EVM implementations.
+
+## Background and Motivation
+
+ITS supports two distinct token deployment approaches:
+
+**Native Interchain Tokens** are deployed directly by ITS using standardized contracts. They must have identical decimals across all chains, and use a simplified `deploy` → `deploy remote` workflow. No metadata registration is required since decimals are uniform.
+
+**Custom Tokens** are existing tokens deployed independently that integrate with ITS through registration and linking. They support different decimal precisions across chains via ITS Hub's automatic scaling. The workflow requires metadata registration on each chain, followed by token registration and explicit linking. Custom tokens cannot use the `NATIVE_INTERCHAIN_TOKEN` manager type.
+
+The ability to link tokens with different decimals is crucial for integrating existing token ecosystems. For example, USDC has 6 decimals on some chains but 18 on others. When linking such tokens, ITS Hub automatically scales amounts (e.g., by 10^12 when transferring from 6 to 18 decimals), ensuring correct token quantities while preserving each chain's native precision.
+
+### Motivation for Sui-Specific Specification
+
+Sui's implementation differs fundamentally from EVM chains in several areas:
+
+1. **Channel-Based Identity**: Uses `Channel` objects instead of addresses for deployer identity
+2. **Type-Based Token Identification**: Sui coins are identified by their full type name (e.g., `package::module::COIN`) rather than by their contract address
+3. **CoinManagement Struct**: Replaces token manager contracts
+4. **Object-Based Capabilities**: `TreasuryCap` objects replace role-based minter permissions
+5. **Chain-Aware Token IDs**: Token ID derivation includes a chain name hash
+
+### Goals
+
+This ARC aims to:
+
+1. Specify Sui's custom token linking implementation within the ITS framework
+3. Clarify key differences from EVM token manager contracts
+4. Provide guidance for developers integrating Sui tokens with ITS
+
+## Requirements
+
+### Technical Requirements
+
+1. **Channel Identity**: Use `Channel` objects for deployer identity and authentication throughout the linking process
+2. **Type Safety**: Utilize Sui's generic type system (`<T>`) for compile-time token type validation
+3. **Token ID Derivation**: Include chain name hash in custom token ID calculation: `keccak256(prefix || chain_hash || deployer || salt)`
+4. **CoinManagement**: Implement token management logic within `CoinManagement` package supporting both `LOCK_UNLOCK` and `MINT_BURN` patterns
+5. **Treasury Cap Management**: Support transfer and reclaim `TreasuryCap` workflow for `MINT_BURN` token managers
+6. **Message Format Compatibility**: Use ABI encoding compatible with EVM ITS implementations
+7. **Salt Format**: Enforce 32-byte salt format (0x + 64 hex characters) matching Sui address format
+8. **Salt Uniqueness**: Prevent reuse of same salt with same deployer `Channel`
+
+### Security Requirements
+
+1. **Channel Ownership Validation**: Verify `Channel` ownership during linking to ensure deployer authentication
+2. **Token Manager Type Validation**: Prevent use of `NATIVE_INTERCHAIN_TOKEN` type for custom tokens
+3. **Same-Chain Prevention**: Block linking tokens to the source chain itself
+4. **Operator Authorization**: Validate `Channel`-based operator permissions for administrative operations
+5. **Treasury Cap Reclamation**: Enable original deployer to reclaim `TreasuryCap` if needed using `TreasuryCapReclaimer`
+6. **Flow Limit Enforcement**: Support flow limits with operator-only modification rights
+
+## Design
+
+### Process Flow Overview
+
+[TODO: Diagram showing the complete Sui custom token linking flow from registration through linking and transfers]
+
+Sui custom token linking follows this workflow:
+
+```
+1. User registers coin metadata on Sui via register_coin_metadata<T>
+   → Sends token type name and decimals to ITS Hub
+   
+2. User registers coin metadata on destination chain
+   → ITS Hub stores decimal mappings for both chains
+
+3. User calls register_custom_coin<T> on Sui
+   → Creates CoinManagement<T> (token manager)
+   → Claims tokenId for deployer Channel + salt
+   → Returns TokenId and optional TreasuryCapReclaimer<T>
+
+4. User calls link_coin with destination token address
+   → Sends LINK_TOKEN message to ITS Hub
+   → ITS Hub calculates scaling factor from stored decimals
+   
+5. Destination chain receives LINK_TOKEN message
+   → Deploys corresponding token manager
+   
+6. ITS Hub processes InterchainTransfer messages with automatic decimal scaling
+```
+
+### Channel-Based Identity Model
+
+Sui uses `Channel` objects for authenticating identities rather than transaction sender addresses. A `Channel` is a Sui object with a unique UID that represents identity (much like an address) across ITS operations:
+
+```move
+public struct Channel has key, store {
+    id: UID,
+}
+```
+
+Since `Channel` is an object the can be owned by any user or contract, note that transferring a `Channel` object to another party transfers all of its capabilities and permissions including operatorship, distributorship, etc.
+
+**Usage in Token Linking:**
+
+The same `Channel` must be used for both `register_custom_coin` and `link_coin` calls which proves the coin deployer's identity, since the token ID is derived from the `Channel`'s address.
+
+### CoinManagement: Sui's Token Manager
+
+In EVM, each token gets a separate `TokenManager` contract that handles locking/unlocking or minting/burning. Sui replaces this with the `CoinManagement` package—a generic structure stored within ITS that manages individual token operations.
+```move
+public struct CoinManagement<phantom T> has store {
+    treasury_cap: Option<TreasuryCap<T>>,// For MINT_BURN
+    balance: Option<Balance<T>>, // For LOCK_UNLOCK
+    distributor: Option<address>, // Minting/burning authority
+    operator: Option<address>, // Administrative authority
+    flow_limit: FlowLimit, // Rate limiting
+    dust: u256, // Rounding dust tracking
+}
+```
+
+#### Key Architectural Differences
+
+| Aspect | EVM TokenManager | Sui CoinManagement |
+|--------|------------------|-------------------|
+| **Deployment** | Separate contract per token | Stored in ITS Bag collection |
+| **Type Safety** | Runtime via address lookup | Compile-time via generic `<T>` |
+| **Authority Model** | Role-based (operator, minter) | Object-based (`TreasuryCap`, `Channel` addresses) |
+| **Minting & Burning** | Calls token.mint(), token.burn() with minter role | Directly mints and burns via `TreasuryCap` |
+| **Locking** | Transfers tokens to/from contract | Joins/splits Balance<T> |
+
+#### CoinManagement Variants
+
+**LOCK_UNLOCK Type:**
+```move
+public fun new_locked<T>(): CoinManagement<T> {
+    CoinManagement<T> {
+        treasury_cap: option::none(),
+        balance: option::some(balance::zero()),
+        distributor: option::none(),
+        operator: option::none(),
+        flow_limit: flow_limit::new(),
+        dust: 0,
+    }
+}
+```
+
+- Stores `Balance<T>` for holding locked tokens
+- No TreasuryCap needed
+- Tokens are locked by joining to balance, unlocked by splitting from balance
+
+**MINT_BURN Type:**
+```move
+public fun new_with_cap<T>(treasury_cap: TreasuryCap<T>): CoinManagement<T> {
+    CoinManagement<T> {
+        treasury_cap: option::some(treasury_cap),
+        balance: option::none(),
+        distributor: option::none(),
+        operator: option::none(),
+        flow_limit: flow_limit::new(),
+        dust: 0,
+    }
+}
+```
+
+- Stores `TreasuryCap<T>` for minting/burning
+- No balance storage needed
+- Tokens are burned by decreasing supply, minted by increasing supply
+
+#### Core Operations
+
+**Taking Tokens (Outbound Transfer):**
+```move
+public(package) fun take_balance<T>(
+    self: &mut CoinManagement<T>, 
+    to_take: Balance<T>, 
+    clock: &Clock
+): u64 {
+    self.flow_limit.add_flow_out(to_take.value(), clock);
+    let amount = to_take.value();
+    if (self.has_treasury_cap()) {
+        self.burn(to_take);  // MINT_BURN: burn tokens
+    } else {
+        self.balance.borrow_mut().join(to_take);  // LOCK_UNLOCK: lock tokens
+    };
+    amount
+}
+```
+
+**Giving Tokens (Inbound Transfer):**
+```move
+public(package) fun give_coin<T>(
+    self: &mut CoinManagement<T>, 
+    amount: u64, 
+    clock: &Clock, 
+    ctx: &mut TxContext
+): Coin<T> {
+    self.flow_limit.add_flow_in(amount, clock);
+    if (self.has_treasury_cap()) {
+        self.mint(amount, ctx)  // MINT_BURN: mint new tokens
+    } else {
+        coin::take(self.balance.borrow_mut(), amount, ctx)  // LOCK_UNLOCK: unlock tokens
+    }
+}
+```
+
+**Flow Limit Management:**
+```move
+public(package) fun set_flow_limit<T>(
+    self: &mut CoinManagement<T>, 
+    channel: &Channel, 
+    flow_limit: Option<u64>
+) {
+    assert!(self.operator.contains(&channel.to_address()), ENotOperator);
+    self.set_flow_limit_internal(flow_limit);
+}
+```
+
+Only the assigned operator `Channel` can modify flow limits, providing security against unauthorized rate limit changes.
+
+### Supported Token Managers
+
+Unlike EVM and other chains, Sui only supports two token manager types for custom tokens:
+
+#### LOCK_UNLOCK (`2`)
+
+Tokens are locked on source chain and unlocked from pre-existing supply on destination chain. Use this manager type for coins that meet the following conditions:
+- Existing tokens with established supply distribution
+- No minting authority available or desired
+- Simple integration without authority transfer
+
+To use this manager type, create a `CoinManagement` using the `new_locked<T>()` function.
+
+#### MINT_BURN (`4`)
+
+Tokens are burned on source chain and minted on destination chain. Use this manager type for coins that meet the following conditions:
+- Dynamic supply management desired
+- New tokens being deployed cross-chain
+- Lock/unlock liquidity insufficient
+
+To use this manager type. create a `CoinManagement` using the `new_with_cap<T>(treasury_cap)` function.
+
+**`MINT_BURN` Requirements:**
+- Deployer must provide `TreasuryCap<T>` 
+- `TreasuryCap` must be transferred to ITS
+- Returns `TreasuryCapReclaimer<T>` for reclaiming the `TreasuryCap`
+
+### Complete Workflow Example
+
+[TODO: Sequence diagram showing: User creates Channel → registers metadata on both chains → registers custom coin → links to destination → optional treasury cap transfer → cross-chain transfer flow]
+
+**Example: Linking Sui Token (LOCK_UNLOCK) to EVM Token (MINT_BURN)**
+
+```move
+// 1. Create deployer Channel
+let deployer = channel::new(ctx);
+
+// 2. Register Sui coin metadata
+let ticket = its.register_coin_metadata<MYTOKEN>(&coin_metadata);
+// Send ticket via relayer
+
+// 3. Register EVM token metadata (via EVM client)
+// its.registerTokenMetadata(evm_token_address, gasValue);
+
+// 4. Register custom coin on Sui
+let salt = bytes32::new(0x0000...0001);
+let coin_management = coin_management::new_locked<MYTOKEN>();
+let (token_id, _) = its .register_custom_coin<MYTOKEN>(
+    &deployer,
+    salt,
+    &coin_metadata,
+    coin_management,
+    ctx
+);
+
+// 5. Link to EVM
+let ticket = its.link_coin(
+    &deployer,
+    salt,
+    ascii::string(b"ethereum"),
+    evm_token_address_bytes,
+    token_manager_type::lock_unlock(),
+    vector::empty()  // No operator
+);
+// Send ticket via relayer
+
+// 6. On EVM: Transfer minter role to token manager (since EVM is MINT_BURN)
+// address tokenManager = its.tokenManagerAddress(tokenId);
+// token.transferMintership(tokenManager);
+
+// 7. Tokens are now linked and ready for transfers
+```
+
+## References
+
+- [ARC-1](./ARC-1.md)
+- [Sui Interchain Token Service](https://github.com/axelarnetwork/axelar-cgp-sui)
+- [EVM Interchain Token Service](https://github.com/axelarnetwork/interchain-token-service)
+- [Sui Token Linking](#tbd)
+- [Sui Channels](#tbd)
+
+## Changelog
+
+|  Date  | Revision  | Author |  Description  |
+|--------|-----------|--------|---------------|
+| 2025-11-3 | v1.0 | Drew Taylor | Initial ARC specification for Sui custom token linking |

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -37,7 +37,7 @@ Sui's implementation differs fundamentally from EVM (and other) chains in severa
 This ARC aims to:
 
 1. Specify Sui's custom token linking implementation within the ITS framework
-3. Clarify key differences from EVM token manager contracts
+2. Clarify key differences from EVM token manager contracts
 4. Provide guidance for developers integrating Sui tokens with ITS
 
 ## Requirements

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -320,7 +320,9 @@ public(package) fun set_flow_limit<T>(
 
 Only the assigned operator `Channel` can modify flow limits, providing security against unauthorized rate limit changes.
 
-### Complete Process Flow
+### Complete Process Flow Example
+
+Sequence flow example with Sui as the source chain (`MINT_BURN`) and an EVM chain as the destination chain (`LOCK_UNLOCK`).
 
 ```mermaid
 sequenceDiagram

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -172,7 +172,7 @@ public fun new_with_cap<T>(treasury_cap: TreasuryCap<T>): CoinManagement<T> {
 - No balance storage needed
 - Tokens are burned by decreasing supply, minted by increasing supply
 
-#### Core Operations
+#### `CoinManagement` Core Operations
 
 **Taking Tokens (Outbound Transfer):**
 ```move

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -112,7 +112,7 @@ public fun to_address(self: &Channel): address {
 
 **Usage in Token Linking:**
 
-The same `Channel` must be used for both `register_custom_coin` and `link_coin` transactions. This proves the coin deployer's identity since the token ID is derived, in both cases, from the `Channel` and user provided `salt`, and the derived token ID must already exist (e.g. match the token ID from `register_custom_coin`) for token linking to succeed.
+The same `Channel` must be used for both `register_custom_coin` and `link_coin` transactions. This proves the coin deployer's identity, since the token ID is derived, in both cases, from the `Channel` and the  `salt`. The derived token ID must already exist (e.g. match the token ID from `register_custom_coin`) for the token linking to succeed.
 
 ### Token Address Encoding
 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -187,11 +187,6 @@ writer
     .write_bytes(link_params);
 ```
 
-The conversion chain is:
-1. `TypeName` → `String` via `.into_string()`
-2. `String` → `vector<u8>` via `.into_bytes()`
-3. Bytes written to ABI-encoded payload
-
 #### Cross-Chain Encoding Differences
 
 **Key Differences:**

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -222,7 +222,17 @@ public struct CoinManagement<phantom T> has store {
 
 #### CoinManagement Variants
 
-**LOCK_UNLOCK Type:**
+Unlike EVM and other chains, Sui only supports two token manager types for custom tokens (`LOCK_UNLOCK` and `MINT_BURN`).
+
+**LOCK_UNLOCK (`2u256`)**
+Tokens are locked on source chain and unlocked from pre-existing supply on destination chain. 
+
+- Stores `Balance<T>` for holding locked tokens
+- No `TreasuryCap` needed
+- Coins are locked by [joining](https://docs.sui.io/references/framework/sui_sui/coin#sui_coin_join) to balance, unlocked by [splitting](https://docs.sui.io/references/framework/sui_sui/coin#sui_coin_split) from balance
+
+To use this manager type, create a `CoinManagement` using the `new_locked<T>()` function.
+
 ```move
 public fun new_locked<T>(): CoinManagement<T> {
     CoinManagement<T> {
@@ -236,11 +246,16 @@ public fun new_locked<T>(): CoinManagement<T> {
 }
 ```
 
-- Stores `Balance<T>` for holding locked tokens
-- No `TreasuryCap` needed
-- Coins are locked by [joining](https://docs.sui.io/references/framework/sui_sui/coin#sui_coin_join) to balance, unlocked by [splitting](https://docs.sui.io/references/framework/sui_sui/coin#sui_coin_split) from balance
+**MINT_BURN (`4u256`)**
 
-**MINT_BURN Type:**
+Tokens are burned on source chain and minted on destination chain.
+
+- Stores `TreasuryCap<T>` for minting/burning
+- No balance storage needed
+- Tokens are burned by decreasing supply, minted by increasing supply
+
+To use this manager type create a `CoinManagement` using the `new_with_cap<T>(treasury_cap)` function.
+
 ```move
 public fun new_with_cap<T>(treasury_cap: TreasuryCap<T>): CoinManagement<T> {
     CoinManagement<T> {
@@ -253,10 +268,6 @@ public fun new_with_cap<T>(treasury_cap: TreasuryCap<T>): CoinManagement<T> {
     }
 }
 ```
-
-- Stores `TreasuryCap<T>` for minting/burning
-- No balance storage needed
-- Tokens are burned by decreasing supply, minted by increasing supply
 
 #### `CoinManagement` Core Operations
 
@@ -308,18 +319,6 @@ public(package) fun set_flow_limit<T>(
 ```
 
 Only the assigned operator `Channel` can modify flow limits, providing security against unauthorized rate limit changes.
-
-### Supported Token Managers
-
-Unlike EVM and other chains, Sui only supports two token manager types for custom tokens:
-
-#### LOCK_UNLOCK (`2u256`)
-
-Tokens are locked on source chain and unlocked from pre-existing supply on destination chain. To use this manager type, create a `CoinManagement` using the `new_locked<T>()` function.
-
-#### MINT_BURN (`4u256`)
-
-Tokens are burned on source chain and minted on destination chain To use this manager type. create a `CoinManagement` using the `new_with_cap<T>(treasury_cap)` function.
 
 ### Complete Process Flow
 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -26,7 +26,7 @@ ITS supports two distinct token linking approaches:
 
 Sui's implementation differs fundamentally from EVM (and other) chains in several areas:
 
-1. **Channel-Based Identity**: Uses `Channel` objects instead of addresses for deployer identity
+1. **Channel-Based Identity**: Uses `Channel` objects instead of addresses for identity authorization
 2. **Type Names for Token Addresses**: Sui coins are identified by their full type name, using the format `package::module::SYMBOL` (example: `0b6345a938be0a9bcd8319ca6b768bfddfffd60f0178d920973a528ef741c639::test::TEST`)
 3. **CoinManagement Struct**: Replaces token manager contracts
 4. **Object-Based Capabilities**: `TreasuryCap` objects replace role-based minter permissions

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -27,7 +27,7 @@ ITS supports two distinct token linking approaches:
 Sui's implementation differs fundamentally from EVM (and other) chains in several areas:
 
 1. **Channel-Based Identity**: Uses `Channel` objects instead of addresses for deployer identity
-2. **Type Names for Token Addresses**: Sui coins are identified by their full type name, using the format `package::module::SYMBOL` (example: `0b6345a938be0a9bcd8319ca6b768bfddfffd60f0178d920973a528ef741c639::test::TEST`), rather than by contract address
+2. **Type Names for Token Addresses**: Sui coins are identified by their full type name, using the format `package::module::SYMBOL` (example: `0b6345a938be0a9bcd8319ca6b768bfddfffd60f0178d920973a528ef741c639::test::TEST`)
 3. **CoinManagement Struct**: Replaces token manager contracts
 4. **Object-Based Capabilities**: `TreasuryCap` objects replace role-based minter permissions
 5. **Chain-Aware Token IDs**: Token ID derivation includes a chain name hash

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -201,7 +201,7 @@ writer
 In EVM, each token gets a separate `TokenManager` contract that handles locking/unlocking or minting/burning. Sui replaces this with the `CoinManagement` package—a generic structure stored within ITS that manages individual token operations.
 ```move
 public struct CoinManagement<phantom T> has store {
-    treasury_cap: Option<TreasuryCap<T>>,// For MINT_BURN
+    treasury_cap: Option<TreasuryCap<T>>, // For MINT_BURN
     balance: Option<Balance<T>>, // For LOCK_UNLOCK
     distributor: Option<address>, // Minting/burning authority
     operator: Option<address>, // Administrative authority

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -428,8 +428,8 @@ sequenceDiagram
 - [Sui Interchain Token Service](https://github.com/axelarnetwork/axelar-cgp-sui)
 - [EVM Interchain Token Service](https://github.com/axelarnetwork/interchain-token-service)
 - [Sui `Coin` Module](https://docs.sui.io/references/framework/sui_sui/coin)
-- [Sui Token Linking](#tbd)
-- [Sui Channels](#tbd)
+- [Sui Token Linking](https://github.com/axelarnetwork/axelar-contract-deployments/blob/98f13c6125c2af35d9c355c97ef414d9b98535a0/sui/docs/link-token.md)
+- [Sui Channels](https://github.com/axelarnetwork/axelar-contract-deployments/blob/3639ea1fdcda6c83aa6674465949111e9731d3cb/sui/docs/channel.md)
 
 ## Changelog
 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -217,8 +217,8 @@ public struct CoinManagement<phantom T> has store {
 | **Deployment** | Separate contract per token | Stored in ITS Bag collection |
 | **Type Safety** | Runtime via address lookup | Compile-time via generic `<T>` |
 | **Authority Model** | Role-based (operator, minter) | Object-based (`TreasuryCap`, `Channel` addresses) |
-| **Minting & Burning** | Calls token.mint(), token.burn() with minter role | Directly mints and burns via `TreasuryCap` |
-| **Locking** | Transfers tokens to/from contract | Joins/splits `Balance<T>` |
+| **Minting / Burning** | Calls token.mint(), token.burn() with minter role | Directly mints and burns via `TreasuryCap` |
+| **Locking / Unlocking** | Transfers tokens to/from contract | Joins/splits `Balance<T>` |
 
 #### CoinManagement Variants
 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -222,7 +222,7 @@ public struct CoinManagement<phantom T> has store {
 
 #### CoinManagement Variants
 
-Unlike EVM and other chains, Sui only supports two token manager types for custom tokens (`LOCK_UNLOCK` and `MINT_BURN`).
+Unlike EVM, and other chains, Sui only supports two token manager types for custom tokens (`LOCK_UNLOCK` and `MINT_BURN`).
 
 **LOCK_UNLOCK (`2u256`)**
 Tokens are locked on source chain and unlocked from pre-existing supply on destination chain. 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -135,7 +135,7 @@ The Sui format consists of three components separated by `::`:
 2. **Module Name**: The Move module containing the coin definition
 3. **Type Name**: The coin's type identifier (typically the coin symbol)
 
-This type-based identification is intrinsic to Move's design—coins aren't separate contract instances but rather instances of a generic `Coin<T>` type where `T` is the specific coin type.
+This type-based identification is intrinsic to Move's design, where coins aren't separate contract instances but rather instances of a generic `Coin<T>` type where `T` is the specific coin type.
 
 #### The Role of `registered_coin_type`
 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -16,13 +16,11 @@ This ARC specifies the implementation of custom token linking for Sui in the Int
 
 ## Background and Motivation
 
-ITS supports two distinct token deployment approaches:
+ITS supports two distinct token linking approaches:
 
-**Native Interchain Tokens**: Tokens deployed directly by ITS using standardized contracts. They must have identical decimals across all chains, and linking uses a **deploy origin** → **deploy remote** workflow. Metadata registration is not required, since decimals are the same on both the origin and destination chains.
+**Native Interchain Tokens**: Tokens deployed directly by ITS using standardized contracts. They must have identical decimals across all chains, and linking uses a **deploy origin** → **deploy remote** workflow. Metadata registration is not required for linking, since decimals are the same on both the origin and destination chains.
 
-**Custom Tokens**: Tokens deployed independently that integrate with ITS through registration and linking. They support different decimal precisions across chains via ITS Hub's automatic scaling. Linking requires metadata registration on each chain, followed by registration in ITS, then explicit linking. Custom tokens cannot use the `NATIVE_INTERCHAIN_TOKEN` token manager type.
-
-The ability to link tokens with different decimals is crucial for integrating existing token ecosystems. For example, USDC has 6 decimals on some chains (e.g. Ethereum, Solana, etc.) but 18 on others (e.g. BNB Chain). When linking tokens with different decimal precisions, ITS Hub automatically scales the decimals ensuring correct token transfer amounts while preserving each chain's native precision.
+**Custom Tokens**: Tokens deployed independently that integrate with ITS. Linking supports different decimal precisions across chains via ITS Hub's automatic scaling. Linking requires metadata registration on each chain, followed by registration in ITS, then explicit linking. Custom tokens cannot use the `NATIVE_INTERCHAIN_TOKEN` token manager type.
 
 ### Motivation for Sui-Specific Token Linking ARC
 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -419,4 +419,4 @@ sequenceDiagram
 |  Date  | Revision  | Author |  Description  |
 |--------|-----------|--------|---------------|
 | 2025-11-03 | v1.0 | Drew Taylor | Initial draft |
-| 2025-11-04 | v1.1 | Drew Taylor | Add address encoding, token linking diagrams |
+| 2025-11-04 | v1.1 | Drew Taylor | Add address encoding, token linking diagram |

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -118,7 +118,7 @@ The same `Channel` must be used for both `register_custom_coin` and `link_coin` 
 
 #### Type Names vs Contract Addresses
 
-Sui identifies coins by their **full type name** rather than contract addresses. This fundamental difference stems from Move's type system, where each coin is defined as a generic type parameter `<T>` rather than a deployed contract instance.
+Sui identifies coins by their **full type name** rather than by contract address. This fundamental difference stems from Move's type system, where each coin is defined as a generic type parameter `<T>` rather than a deployed contract instance.
 
 **EVM Token Address Format:**
 ```

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -70,7 +70,7 @@ Sui custom token linking uses the following workflow:
 
 ```
 1. User registers coin metadata on Sui via register_coin_metadata<T>
-   → Sends token type name and decimals to ITS Hub
+   → Sends token type, name, and decimals to ITS Hub
    
 2. User registers coin metadata on destination chain
    → ITS Hub stores decimal mappings for both chains

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -102,7 +102,7 @@ public struct Channel has key, store {
 
 Since `Channel` is an object the can be owned by any user or contract, transferring a `Channel` object to another party transfers all of its capabilities and permissions (including operatorship, and distributorship).
 
-For convenience, `Channel`s can be converted to an address format using the `to_address` helper function:
+For convenience, a `Channel` can be converted to an address format using the `to_address` helper function:
 
 ```move
 public fun to_address(self: &Channel): address {

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -38,7 +38,7 @@ This ARC aims to:
 
 1. Specify Sui's custom token linking implementation within the ITS framework
 2. Clarify key differences from EVM token manager contracts
-4. Provide guidance for developers integrating Sui tokens with ITS
+3. Provide guidance for developers integrating Sui coins with ITS
 
 ## Requirements
 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -100,7 +100,7 @@ public struct Channel has key, store {
 }
 ```
 
-Since `Channel` is an object the can be owned by any user or contract, transferring a `Channel` object to another party transfers all of its capabilities and permissions (including operatorship, and distributorship).
+Since a `Channel` is an object that can be owned by any user or contract, transferring a `Channel` object to another party transfers all of its capabilities and permissions (including operatorship, and distributorship).
 
 For convenience, `Channel`s can be converted to an address format using the `to_address` helper function:
 

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -254,48 +254,6 @@ To use this manager type. create a `CoinManagement` using the `new_with_cap<T>(t
 
 [TODO: Sequence diagram showing: User creates Channel → registers metadata on both chains → registers custom coin → links to destination → optional treasury cap transfer → cross-chain transfer flow]
 
-**Example: Linking Sui Token (LOCK_UNLOCK) to EVM Token (MINT_BURN)**
-
-```move
-// 1. Create deployer Channel
-let deployer = channel::new(ctx);
-
-// 2. Register Sui coin metadata
-let ticket = its.register_coin_metadata<MYTOKEN>(&coin_metadata);
-// Send ticket via relayer
-
-// 3. Register EVM token metadata (via EVM client)
-// its.registerTokenMetadata(evm_token_address, gasValue);
-
-// 4. Register custom coin on Sui
-let salt = bytes32::new(0x0000...0001);
-let coin_management = coin_management::new_locked<MYTOKEN>();
-let (token_id, _) = its .register_custom_coin<MYTOKEN>(
-    &deployer,
-    salt,
-    &coin_metadata,
-    coin_management,
-    ctx
-);
-
-// 5. Link to EVM
-let ticket = its.link_coin(
-    &deployer,
-    salt,
-    ascii::string(b"ethereum"),
-    evm_token_address_bytes,
-    token_manager_type::lock_unlock(),
-    vector::empty()  // No operator
-);
-// Send ticket via relayer
-
-// 6. On EVM: Transfer minter role to token manager (since EVM is MINT_BURN)
-// address tokenManager = its.tokenManagerAddress(tokenId);
-// token.transferMintership(tokenManager);
-
-// 7. Tokens are now linked and ready for transfers
-```
-
 ## References
 
 - [ARC-1](./ARC-1.md)

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -225,7 +225,7 @@ public struct CoinManagement<phantom T> has store {
 Unlike EVM, and other chains, Sui only supports two token manager types for custom tokens (`LOCK_UNLOCK` and `MINT_BURN`).
 
 **LOCK_UNLOCK (`2u256`)**
-Tokens are locked on source chain and unlocked from pre-existing supply on destination chain. 
+Tokens are locked on the source chain and unlocked from pre-existing supply on the destination chain. 
 
 - Stores `Balance<T>` for holding locked tokens
 - No `TreasuryCap` needed
@@ -248,7 +248,7 @@ public fun new_locked<T>(): CoinManagement<T> {
 
 **MINT_BURN (`4u256`)**
 
-Tokens are burned on source chain and minted on destination chain.
+Tokens are burned on the source chain and minted on the destination chain.
 
 - Stores `TreasuryCap<T>` for minting/burning
 - No balance storage needed

--- a/ARCs/ARC-17.md
+++ b/ARCs/ARC-17.md
@@ -77,7 +77,7 @@ Sui custom token linking uses the following workflow:
 
 3. User calls register_custom_coin<T> on Sui
    → Creates CoinManagement<T> (token manager)
-   → Claims tokenId for deployer Channel + salt
+   → Claims TokenId for deployer Channel + salt
    → Returns TokenId and optional TreasuryCapReclaimer<T>
 
 4. User calls link_coin with the destination token address


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds ARC-17 spec documenting Sui custom token linking in ITS, including Channel identity, CoinManagement, encoding, workflows, and security/requirements.
> 
> - **Docs**:
>   - Add `ARCs/ARC-17.md` specifying Sui custom token linking in ITS.
>   - Covers `Channel`-based identity, token ID derivation with chain hash, Sui type-name address encoding, and ABI message composition.
>   - Defines `CoinManagement` (variants `LOCK_UNLOCK`, `MINT_BURN`), flow limits, operator/distributor auth, and `TreasuryCap` reclaim flow.
>   - Provides end-to-end linking workflow, cross-chain encoding differences, references, and changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b2bab76539366ddd874bc0012a700a956bc1f36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->